### PR TITLE
Add optional max_history_length argument to NetSuite class

### DIFF
--- a/netsuite_bbc/client.py
+++ b/netsuite_bbc/client.py
@@ -77,7 +77,8 @@ class NetSuite:
         wsdl_url: str = None,
         cache: zeep.cache.Base = None,
         session: requests.Session = None,
-        sandbox: bool = None
+        sandbox: bool = None,
+        max_history_length: int = 10,
     ) -> None:
 
         if sandbox is not None:
@@ -97,7 +98,7 @@ class NetSuite:
         self.__cache = cache
         self.__session = session
 
-        self.history = HistoryPlugin(maxlen=10)
+        self.history = HistoryPlugin(maxlen=max_history_length)
 
     @cached_property
     def wsdl_url(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup_kwargs = dict(
     name='netsuite-bbc-python',
-    version='1.0.0',
+    version='1.0.1',
     description='Wrapper around Netsuite SuiteTalk Web Services',
     packages=['netsuite_bbc'],
     include_package_data=True,


### PR DESCRIPTION
Default is set to 10. This argument sets the maximum number of raw
responses received from NetSuite Web Services via the HistoryPlugin.