### PR TITLE
feat: enable service endpoint override

### DIFF
--- a/netsuite_bbc/client.py
+++ b/netsuite_bbc/client.py
@@ -63,7 +63,7 @@ def WebServiceCall(
 
 
 class NetSuite:
-    version = '2018.1.0'
+    version = '2018.2.0'
     company_url_tmpl = 'https://{account_id}.suitetalk.api.netsuite.com'
     wsdl_url_tmpl = 'https://{account_id}.suitetalk.api.netsuite.com/wsdl/v{underscored_version}/netsuite.wsdl'
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup_kwargs = dict(
     name='netsuite-bbc-python',
-    version='1.0.1',
+    version='1.1.0',
     description='Wrapper around Netsuite SuiteTalk Web Services',
     packages=['netsuite_bbc'],
     include_package_data=True,


### PR DESCRIPTION
### Story
https://app.shortcut.com/bluebottlecoffee/story/27044/update-netsuite-wsdl-used-in-airflow

### Description
Enables service endpoint override. WSDL versions above 2018.2.0 require use of account-specific endpoint, but Zeep is defaulting to the standard endpoint, resulting in the following error when using WSDL versions 2019.1.0 and above:

> In this account, you must use account-specific domains with this SOAP web services endpoint. You can use the SOAP getDataCenterUrls operation to obtain the correct domain. Or, go to Setup > Company > Company Information in the NetSuite UI. Your domains are listed on the Company URLs tab

Also sets default WSDL version to 2018.2.0 ahead of NetSuite's deprecation of 2018.1.0 in Release 2025.1.
